### PR TITLE
Created download and munki recipes for new Suspicious Package .app format

### DIFF
--- a/SuspiciousPackageApp/SuspiciousPackageApp.download.recipe
+++ b/SuspiciousPackageApp/SuspiciousPackageApp.download.recipe
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of the Suspicious Package application.</string>
+	<key>Identifier</key>
+	<string>com.github.jps3.download.SuspiciousPackageApp</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>SuspiciousPackageApp</string>
+		<key>PKG_URL</key>
+		<string>http://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%PKG_URL%</string>				
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Suspicious Package.app</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Application: Randy Saldinger (936EB786NH)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SuspiciousPackageApp/SuspiciousPackageApp.munki.recipe
+++ b/SuspiciousPackageApp/SuspiciousPackageApp.munki.recipe
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of the Suspicious Package application, and imports into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.jps3.munki.SuspiciousPackageApp</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>SuspiciousPackageApp</string>
+		<key>repo_subdirectory</key>
+		<string>apps/mothersruin</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>display_name</key>
+			<string>Suspicious Package App</string>
+			<key>description</key>
+			<string>Suspicious Package: An application adding Quick Look functionality for OS X Installer Packages. What's in that OS X Installer package? With Suspicious Package, you can find out quickly and safely from the Finder. Select a package, and hit the space bar. http://www.mothersruin.com/software/SuspiciousPackage/</string>
+			<key>minimum_os_version</key>
+			<string>10.9</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.2</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jps3.download.SuspiciousPackageApp</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Version 3.0 of Suspicious Package pivots from a QL plug-in to a standalone .app.  I've created a new set of recipes (SuspiciousPackageApp) since it is a significant change and basically new software. The original distribution mode the developer was using was an obscure .xip format that doesn't play with autopkg.  I contacted the developer and he's agreed to continue making .dmgs since there is value in it for us.  He's added the dmg link to the site's FAQ at http://www.mothersruin.com/software/SuspiciousPackage/faq.html#dmg.

Since you had the original QuickLook variety I thought I'd give you first dibs on the .app recipes.  If you aren't interested in maintaining these I'd be glad to host them in my repo.  Let me know.

-Eric