### PR TITLE
Update SuspiciousPackageQLP for dmg installer

### DIFF
--- a/SuspiciousPackageQLP/SuspiciousPackageQLP.download.recipe
+++ b/SuspiciousPackageQLP/SuspiciousPackageQLP.download.recipe
@@ -16,7 +16,7 @@
 			Oh, the irony, SuspiciousPackage!
 		-->
 		<key>pkg_url</key>
-		<string>http://www.mothersruin.com/software/downloads/SuspiciousPackage.pkg</string>
+		<string>http://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>
@@ -38,12 +38,12 @@
 			<dict>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Randy Saldinger (936EB786NH)</string>
+					<string>Developer ID Application: Randy Saldinger (936EB786NH)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%pathname%</string>
+				<string>%pathname%/Suspicious Package*.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/SuspiciousPackageQLP/SuspiciousPackageQLP.munki.recipe
+++ b/SuspiciousPackageQLP/SuspiciousPackageQLP.munki.recipe
@@ -42,95 +42,11 @@ exit 0
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
+			<string>AppDmgVersioner</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkgroot</string>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Library</key>
-					<string>0755</string>
-					<key>QuickLook</key>
-					<string>0755</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>purge_destinateion</key>
-				<true/>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkg_contents</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkg_contents</string>
-				<key>flat_pkg_path</key>
+				<key>dmg_path</key>
 				<string>%pathname%</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkg_contents/*.pkg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>purge_destination</key>
-				<true/>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkgroot</string>
-				<key>pkg_payload_path</key>
-				<string>%found_filename%/Payload</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiInstallsItemsCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>faux_root</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkgroot</string>
-				<key>installs_item_paths</key>
-				<array>
-					<string>/Library/QuickLook/Suspicious Package.qlgenerator</string>
-				</array>
-				<key>version_comparison_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/tmp_pkgroot/Library/QuickLook/Suspicious Package.qlgenerator/Contents/Info.plist</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
 			</dict>
 		</dict>
 		<dict>
@@ -140,18 +56,6 @@ exit 0
 			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/tmp_pkgroot</string>
-					<string>%RECIPE_CACHE_DIR%/tmp_pkg_contents</string>
-				</array>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
SuspiciousPackageQLP used to ship a .pkg file and has now moved to a
.xip file by default. Fortunately, according the FAQ  there is also a
.dmg file that is downloadable (http://www.mothersruin.com/software/SuspiciousPackage/faq.html#dmg )

This commit updates:
  * the download recipe to download the .dmg file rather than the .pkg
  * the signature verification to use the developer's application signature, rather than the installer signture
  * refactors the munki recipe to use the .dmg file, rather than the .pkg  file

