### PR TITLE
Update WacomIntuosProDriver.munki.recipe

### DIFF
--- a/WacomIntuosProDriver/WacomIntuosProDriver.munki.recipe
+++ b/WacomIntuosProDriver/WacomIntuosProDriver.munki.recipe
@@ -158,19 +158,16 @@ exit 0
 				<string>MunkiPkginfoMerger</string>
 			</dict>
 			<dict>
-				<key>Processor</key>
-				<string>PlistReader</string>
-				<key>Arguments</key>
-				<dict>
-					<key>plist_keys</key>
-					<dict>
-						<key>LSMinimumSystemVersion</key>
-						<string>minimum_os_version</string>
-					</dict>
-					<key>info_path</key>
-					<string>%RECIPE_CACHE_DIR%/faux_root/Applications/Wacom Tablet.localized/Wacom Desktop Center.app/Contents/Info.plist</string>
-				</dict>
-			</dict>
+    	        <key>Processor</key>
+    	        <string>URLTextSearcher</string>
+    	        <key>Arguments</key>
+    	        <dict>
+    	            <key>url</key>
+                    <string>file://localhost/%RECIPE_CACHE_DIR%/pkgtmp/Distribution</string>
+    	            <key>re_pattern</key>
+                    <string>&lt;os-version min="(?P&lt;minimum_os_version&gt;.*?)"/&gt;</string>
+    	        </dict>
+    	    </dict>
 			<dict>
 				<key>Processor</key>
 				<string>MunkiPkginfoMerger</string>


### PR DESCRIPTION
Latest WacomIntuosProDriver causes the current version recipe to fail:

```
Key 'LSMinimumSystemVersion' could not be found in the plist /Users/foo/Library/AutoPkg/Cache/local.munki.WacomIntuosProDriver/faux_root/Applications/Wacom Tablet.localized/Wacom Desktop Center.app/Contents/Info.plist!
```

The minimum os version has moved to a different key and format in the Info.plist, and it does not agree with the minimum os version as defined in the package's Distribution file. (10.8 vs 10.9.0)

This proposed change uses URLTextSearcher to find text like <os-version min="10.9.0"/> in the pkg Distribution file to determine the minimum_os_version.