### PR TITLE
Code sig ver note for OpenSCAD

### DIFF
--- a/OpenSCAD/OpenSCAD.download.recipe
+++ b/OpenSCAD/OpenSCAD.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest OpenSCAD.</string>
+	<string>Downloads the latest OpenSCAD.
+	Note: Code signature verification for OpenSCAD cannot be done at this time.</string>
 	<key>Identifier</key>
 	<string>com.github.jps3.download.OpenSCAD</string>
 	<key>Input</key>


### PR DESCRIPTION
Added a note that code signature verification isn't going to happen for OpenSCAD:
```
codesign --display -r- --deep -v /Applications/OpenSCAD.app 
/Applications/OpenSCAD.app: code object is not signed at all
```