### PR TITLE
Removed CodeSignatureVerifier from VueScan.munki.recipe.

### DIFF
--- a/VueScan/VueScan.munki.recipe
+++ b/VueScan/VueScan.munki.recipe
@@ -42,21 +42,6 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/%APPNAME%</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Application: Edward Hamrick</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Removed CodeSignatureVerifier for two reasons:
1) Using 'expected_authority_names' to verify .app bundles is deprecated and may be removed in a future AutoPkg release.
2) Parent download recipe (com.github.hansen-m.download.VueScan) now includes CodeSignatureVerifier using the current 'requirement' argument to verify .app bundles; a second, redundant CodeSignatureVerifier process in the VueScan.munki recipe is not needed.