### PR TITLE
Replaced expected_authority_names with requirement string

### DIFF
--- a/VueScan/VueScan.pkg.recipe
+++ b/VueScan/VueScan.pkg.recipe
@@ -58,12 +58,10 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pkgroot%/Applications/%NAME%.app</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Application: Edward Hamrick</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
+				<key>requirement</key>
+				<string>identifier "com.hamrick.vuescan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5D5BXT9KP5"</string>
+				<key>strict_verification</key>
+				<true />
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Using `expected_authority_names` with .app bundles is no longer supported in AutoPkg 1.0.3.