### PR TITLE
Restore missing array close tag

### DIFF
--- a/InVesalius/InVesalius.munki.recipe
+++ b/InVesalius/InVesalius.munki.recipe
@@ -99,5 +99,6 @@
 		</dict>
     </array>
     -->
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
`plutil -lint` fails without the array close tag. 