### PR TITLE
CuraUrlProvider.py

### DIFF
--- a/Cura/CuraUrlProvider.py
+++ b/Cura/CuraUrlProvider.py
@@ -18,6 +18,7 @@
 #    AutoPkg/autopkglib/SparkleUpdateInfoProvider.py
 #
 
+import urllib
 import urllib2
 import platform
 from distutils.version import LooseVersion
@@ -61,7 +62,7 @@ class CuraUrlProvider(Processor):
             for item in root.iterfind('release'):
                 if item.get('os').lower() == 'darwin':
                     filename = item.find('filename').text
-                    filepath = "current/{fn}".format(fn=filename)
+                    filepath = urllib.quote("current/{fn}".format(fn=filename))
             assert filepath is not None
         except Exception as e:
             raise ProcessorError(


### PR DESCRIPTION
Updated provider to quote URLEncode the returned file path as the
recipe has been failing as per the below:

```
CuraUrlProvider
{'Input': {'update_url_stub': u'https://software.ultimaker.com'}}
CuraUrlProvider: Found download Cura download URL:
https://software.ultimaker.com/current/Ultimaker Cura-3.2.1-Darwin.dmg
{'Output': {'url': u'https://software.ultimaker.com/current/Ultimaker
Cura-3.2.1-Darwin.dmg'}}
URLDownloader
{'Input': {'url': u'https://software.ultimaker.com/current/Ultimaker
Cura-3.2.1-Darwin.dmg'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting
default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value
of: /usr/bin/curl
Curl failure: The requested URL returned error: 404 Not Found (exit
code 22)
Failed.
Receipt written to
/Users/btoms/Library/AutoPkg/Cache/com.github.jps3.download.Cura/receipt
s/Cura.download-receipt-20180315-162936.plist

The following recipes failed:

/Users/btoms/Git/other-recipes/jps3-recipes/Cura/Cura.download.recipe
Error in com.github.jps3.download.Cura: Processor:
URLDownloader: Error: Curl failure: The requested URL returned error:
404 Not Found (exit code 22)
```