### PR TITLE
Objective-See recipe fixes

### DIFF
--- a/Objective-See/BlockBlock.download.recipe
+++ b/Objective-See/BlockBlock.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/blockblock.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -31,6 +31,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -74,6 +78,8 @@
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objectiveSee.BlockBlock" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
                     <!-- See notice on Objective-See web site regarding (temp) signing certs. As of this date and time, I saved to the Wayback Machine, you can see the notice at: https://web.archive.org/web/20171009164747/https://objective-see.com/products/blockblock.html -->
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/DHS.download.recipe
+++ b/Objective-See/DHS.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/dhs.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -31,6 +31,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -62,6 +66,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.DHS" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/KextViewr.download.recipe
+++ b/Objective-See/KextViewr.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/kextviewr.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -31,6 +31,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -62,6 +66,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.KextViewr" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/KnockKnock.download.recipe
+++ b/Objective-See/KnockKnock.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/knockknock.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -31,6 +31,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -62,6 +66,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.KnockKnock" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/Lockdown.download.recipe
+++ b/Objective-See/Lockdown.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/lockdown.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -30,6 +30,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -61,6 +65,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.Lockdown" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/Ostiarius.download.recipe
+++ b/Objective-See/Ostiarius.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/ostiarius.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -30,6 +30,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -61,6 +65,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objectiveSee.Ostiarius" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/OverSight.download.recipe
+++ b/Objective-See/OverSight.download.recipe
@@ -14,7 +14,7 @@
 		<string>OverSight</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -28,6 +28,10 @@
 				<string>"(?P&lt;url&gt;https://bitbucket.org/objective-see/deploy/downloads/%NAME%.*\.zip)"</string>
 				<key>url</key>
 				<string>%DOWNLOAD_PAGE_URL%</string>
+				<key>curl_opts</key>
+				<array>
+					<string>--compress</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -58,6 +62,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%_Installer.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.objectiveSee.OverSight-Installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+				<key>strict_verification</key>
+				<true />
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -69,6 +75,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%_Installer.app/Contents/Resources/%NAME%.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.objective-see.OverSight" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+				<key>strict_verification</key>
+				<true />
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Objective-See/TaskExplorer.download.recipe
+++ b/Objective-See/TaskExplorer.download.recipe
@@ -14,7 +14,7 @@
             <string>https://objective-see.com/products/taskexplorer.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -31,6 +31,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -62,6 +66,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.TaskExplorer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>

--- a/Objective-See/WhatsYourSign.download.recipe
+++ b/Objective-See/WhatsYourSign.download.recipe
@@ -16,7 +16,7 @@
             <string>https://objective-see.com/products/whatsyoursign.html</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.4.0</string>
+        <string>1.0.4</string>
         <key>Process</key>
         <array>
             <dict>
@@ -34,6 +34,10 @@
                     <key>re_flags</key>
                     <array>
                         <string>IGNORECASE</string>
+                    </array>
+                    <key>curl_opts</key>
+                    <array>
+                        <string>--compress</string>
                     </array>
                 </dict>
             </dict>
@@ -88,6 +92,8 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/%INSTALLER_APP_NAME%</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "com.objective-see.WhatsYourSign" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
             </dict>
         </array>


### PR DESCRIPTION
Added `--compress` curl option to fix URLTextSearcher errors and enabled strict code signature verification for a number of Objective-See download recipes.
