### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Arduino/Arduino.download.recipe
+++ b/Arduino/Arduino.download.recipe
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app/Contents/Info.plist</string>
 			</dict>
 		</dict>
         <dict>
@@ -65,7 +65,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app</string>
                 <key>requirement</key>
                 <string>identifier "cc.arduino.Arduino" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7KT7ZWMCJT"</string>
             </dict>

--- a/Arduino/Arduino.pkg.recipe
+++ b/Arduino/Arduino.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Arduino.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/BetterZip/BetterZip.download.recipe
+++ b/BetterZip/BetterZip.download.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/BetterZip.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -56,7 +56,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/BetterZip.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.macitbetter.betterzip" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "79RR9LPM2N")</string>
             </dict>

--- a/Cura/cura-lulzbot.munki.recipe
+++ b/Cura/cura-lulzbot.munki.recipe
@@ -48,7 +48,7 @@
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>munkiimport_appname</key>
-				<string>%NAME%.app</string>
+				<string>cura-lulzbot.app</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Fritzing/Fritzing.pkg.recipe
+++ b/Fritzing/Fritzing.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Fritzing.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Fritzing.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/OpenSCAD/OpenSCAD.pkg.recipe
+++ b/OpenSCAD/OpenSCAD.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/OpenSCAD.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/OpenSCAD.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Pashua/Pashua.munki.recipe
+++ b/Pashua/Pashua.munki.recipe
@@ -39,7 +39,7 @@ http://www.bluem.net/en/mac/pashua/
             <key>Arguments</key>
             <dict>
                 <key>munkiimport_appname</key>
-                <string>%NAME%.app</string>
+                <string>Pashua.app</string>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>version_comparison_key</key>

--- a/Pashua/Pashua.pkg.recipe
+++ b/Pashua/Pashua.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Pashua.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleVersion</key>
@@ -51,9 +51,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Pashua.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Pashua.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Scout-App/Scout-App.munki.recipe
+++ b/Scout-App/Scout-App.munki.recipe
@@ -22,9 +22,9 @@
             <true/>
             <key>postinstall_script</key>
             <string>#!/bin/bash
-# We need to fix some permissions of important files which do not 
+# We need to fix some permissions of important files which do not
 # have group or other set, preventing application launch
-find /Applications/%NAME%.app -type f -perm +0700 ! -perm +0055 -exec chmod go+rx {} +
+find /Applications/Scout-App.app -type f -perm +0700 ! -perm +0055 -exec chmod go+rx {} +
 exit 0
             </string>
         </dict>

--- a/Slic3r/Slic3r.download.recipe
+++ b/Slic3r/Slic3r.download.recipe
@@ -53,7 +53,7 @@
         <key>Arguments</key>
         <dict>
           <key>input_plist_path</key>
-          <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+          <string>%pathname%/Slic3r.app/Contents/Info.plist</string>
           <key>plist_version_key</key>
           <string>CFBundleVersion</string>
         </dict>

--- a/Soulver/Soulver.munki.recipe
+++ b/Soulver/Soulver.munki.recipe
@@ -22,7 +22,7 @@
 			<string>Soulver helps you work things out. It's quicker to use than a spreadsheet, and smarter and clearer than a traditional calculator. Use Soulver to play around with numbers, do "back of the envelope" quick calculations, and solve day-to-day problems.</string>
 			<key>blocking_applications</key>
 			<array>
-				<string>%NAME%.app</string>
+				<string>Soulver.app</string>
 			</array>
 		</dict>
 	</dict>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Soulver.app/Contents/Info.plist</string>
 			</dict>
 		</dict>
 		<dict>

--- a/TotalTerminal/TotalTerminal.munki.recipe
+++ b/TotalTerminal/TotalTerminal.munki.recipe
@@ -43,7 +43,7 @@
                     <true/>
                     <key>blocking_applications</key>
                     <array>
-                        <string>%NAME%</string>
+                        <string>TotalTerminal</string>
                         <string>Terminal</string>
                         <string>TotalTerminalCrashWatcher</string>
                     </array>
@@ -73,7 +73,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%_unpacked</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%_expanded/%NAME%_Plugin.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%_expanded/TotalTerminal_Plugin.pkg/Payload</string>
             </dict>
         </dict>
         <dict>
@@ -85,8 +85,8 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%_unpacked</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/%NAME%.app</string>
-                    <string>/Library/ScriptingAdditions/%NAME%.osax</string>
+                    <string>/Applications/TotalTerminal.app</string>
+                    <string>/Library/ScriptingAdditions/TotalTerminal.osax</string>
                 </array>
             </dict>
         </dict>

--- a/VueScan/VueScan.munki.recipe
+++ b/VueScan/VueScan.munki.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>VueScan</string>
         <key>APPNAME</key>
-        <string>%NAME%.app</string>
+        <string>VueScan.app</string>
         <key>repo_subdirectory</key>
         <string>apps/VueScan</string>
 		<key>pkginfo</key>

--- a/VueScan/VueScan.pkg.recipe
+++ b/VueScan/VueScan.pkg.recipe
@@ -46,9 +46,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/VueScan.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/VueScan.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -57,7 +57,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/VueScan.app</string>
 				<key>requirement</key>
 				<string>identifier "com.hamrick.vuescan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5D5BXT9KP5"</string>
 				<key>strict_verification</key>

--- a/X-Rite/i1Diagnostics.download.recipe
+++ b/X-Rite/i1Diagnostics.download.recipe
@@ -37,7 +37,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/i1Diagnostics.app</string>
                 <key>expected_authority_names</key>
 	            <array>
 	                <string>Developer ID Application: X-Rite, Incorporated</string>

--- a/X-Rite/i1Diagnostics.munki.recipe
+++ b/X-Rite/i1Diagnostics.munki.recipe
@@ -40,7 +40,7 @@
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>munkiimport_appname</key>
-                <string>%NAME%.app</string>
+                <string>i1Diagnostics.app</string>
             </dict>
         </dict>
 	</array>

--- a/fseventer/fseventer.download.recipe
+++ b/fseventer/fseventer.download.recipe
@@ -55,7 +55,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/**/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/**/fseventer.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/fseventer/fseventer.munki.recipe
+++ b/fseventer/fseventer.munki.recipe
@@ -70,7 +70,7 @@ exit 0
 					<true/>
 					<key>blocking_applications</key>
 					<array>
-						<string>%NAME%</string>
+						<string>fseventer</string>
 					</array>
 				</dict>
 			</dict>
@@ -84,7 +84,7 @@ exit 0
 				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/%NAME%.app</string>					
+					<string>/Applications/fseventer.app</string>
 				</array>
 				<key>version_comparison_key</key>
 				<string>CFBundleVersion</string>

--- a/fseventer/fseventer.pkg.recipe
+++ b/fseventer/fseventer.pkg.recipe
@@ -39,7 +39,7 @@
 				<key>source_path</key>
 				<string>%found_filename%</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/fseventer.app</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.