### PR TITLE
Use URLGetter superclass for PathFinderURLProvider, handle Path Finder disk image

### DIFF
--- a/PathFinder/PackageInfoTemplate
+++ b/PathFinder/PackageInfoTemplate
@@ -1,2 +1,0 @@
-<pkg-info format-version="2" identifier="com.cocoatech.PathFinder.pkg" install-location="/" auth="root">
-</pkg-info>

--- a/PathFinder/PathFinder.download.recipe
+++ b/PathFinder/PathFinder.download.recipe
@@ -20,7 +20,7 @@
         <string>PF7.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>1.4</string>
     <key>Process</key>
     <array>
         <dict>
@@ -37,31 +37,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%/*.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%found_filename%</string>
+                <string>%pathname%/Path Finder.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.cocoatech.PathFinder" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MQ76M469AB)</string>
             </dict>

--- a/PathFinder/PathFinder.munki.recipe
+++ b/PathFinder/PathFinder.munki.recipe
@@ -26,36 +26,21 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-            <key>blocking_applications</key>
-            <array>
-                <string>%NAME%</string>
-            </array>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.4</string>
     <key>ParentRecipe</key>
     <string>com.github.jps3.download.PathFinder</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%dmg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/PathFinder/PathFinder.pkg.recipe
+++ b/PathFinder/PathFinder.pkg.recipe
@@ -10,81 +10,16 @@
 	<dict>
 		<key>NAME</key>
 		<string>PathFinder</string>
-		<key>APPNAME</key>
-		<string>Path Finder.app</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.4</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jps3.download.PathFinder</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Copier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>source_path</key>
-				<string>%destination_path%/%APPNAME%</string>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%APPNAME%</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgInfoCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>template_path</key>
-				<string>PackageInfoTemplate</string>
-				<key>infofile</key>
-				<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-				<key>pkgtype</key>
-				<string>flat</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>id</key>
-					<string>com.cocoatech.PathFinder.pkg</string>
-					<key>resources</key>
-					<string>Resources</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-							<key>group</key>
-							<string>admin</string>
-						</dict>
-					</array>
-				</dict>
-			</dict>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/PathFinder/PathFinderURLProvider.py
+++ b/PathFinder/PathFinderURLProvider.py
@@ -4,17 +4,12 @@ from __future__ import absolute_import
 
 import xml.etree.ElementTree as ET
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["PathFinderURLProvider"]
 
 
-class PathFinderURLProvider(Processor):
+class PathFinderURLProvider(URLGetter):
 
     description = "Provides URL for the latest version of PathFinder."
     input_variables = {}
@@ -34,12 +29,11 @@ class PathFinderURLProvider(Processor):
         """Identify and return the download URL for the latest version of PathFinder"""
         update_url = "%s/%s" % (self.env['UPDATE_XML_HOST'], self.env['UPDATE_XML_PATH'])
         try:
-            f = urlopen(update_url)
+            xml = self.download(update_url, text=True)
         except Exception as e:
             raise ProcessorError("Unable to download %s: %s" % (update_url, e))
 
         try:
-            xml = f.read()
             doc = ET.fromstring(xml)
         except Exception as e:
             raise ProcessorError("Error attempting to parse XML data from update feed at: %s (Error: %s)" % (update_url, e) )


### PR DESCRIPTION
This PR updates PathFinderURLProvider to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), which should ease the transition to Python 3 and AutoPkg 2.

The Path Finder recipes have also been updated to handle the downloaded disk image, rather than the zip file that contained previous Path Finder versions.

Verbose run log:
https://gist.github.com/homebysix/908eb0592f8a802f57067133a60cd851