### PR TITLE
Deprecate Nvidia CUDA recipes

### DIFF
--- a/NVIDIA/NvidiaCudaDriver.download.recipe
+++ b/NVIDIA/NvidiaCudaDriver.download.recipe
@@ -18,6 +18,19 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Nvidia CUDA 10.2 (toolkit and driver) was the last release to support macOS. Details:
+	- https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#title-new-features
+	- https://mjtsai.com/blog/2019/11/25/nvidia-drops-cuda-support-for-macos/
+	- https://gizmodo.com/apple-and-nvidia-are-over-1840015246
+				</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>


### PR DESCRIPTION
Nvidia CUDA 10.2 (toolkit and driver) was the last release to support macOS. Details:

- https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#title-new-features
- https://mjtsai.com/blog/2019/11/25/nvidia-drops-cuda-support-for-macos/
- https://gizmodo.com/apple-and-nvidia-are-over-1840015246

Related: https://github.com/autopkg/novaksam-recipes/pull/68, https://github.com/autopkg/jessepeterson-recipes/pull/96