### PR TITLE
Appcast URL change

### DIFF
--- a/OpenSCAD/OpenSCAD.download.recipe
+++ b/OpenSCAD/OpenSCAD.download.recipe
@@ -30,7 +30,7 @@
 		        At least the appcast.xml origin is reasonably verifiable.
 		-->
 		<key>APPCAST_URL</key>
-		<string>https://openscad.github.com/appcast.xml</string>
+		<string>https://openscad.github.io/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>


### PR DESCRIPTION
The URL for the appcast changed, here is the output:

```
~ autopkg run -vv OpenSCAD.pkg                                                                           
Processing OpenSCAD.pkg...
WARNING: OpenSCAD.pkg is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://openscad.github.io/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2019.05.10
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2019.05
SparkleUpdateInfoProvider: Found URL https://files.openscad.org/OpenSCAD-2019.05.dmg
{'Output': {'url': 'https://files.openscad.org/OpenSCAD-2019.05.dmg',
            'version': '2019.05'}}
URLDownloader
{'Input': {'url': 'https://files.openscad.org/OpenSCAD-2019.05.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 19 May 2019 00:16:55 GMT
URLDownloader: Storing new ETag header: "5ce0a077-18a1aed"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg
{'Output': {'download_changed': True,
            'etag': '"5ce0a077-18a1aed"',
            'last_modified': 'Sun, 19 May 2019 00:16:55 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
AppDmgVersioner
{'Input': {'dmg_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg'}}
AppDmgVersioner: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg
AppDmgVersioner: BundleID: org.openscad.OpenSCAD
AppDmgVersioner: Version: 2019.05
{'Output': {'app_name': 'OpenSCAD.app',
            'bundleid': 'org.openscad.OpenSCAD',
            'version': '2019.05'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot'}}
PkgRootCreator: Created /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot/Applications/OpenSCAD.app',
           'source_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg/OpenSCAD.app'}}
Copier: Parsed dmg results: dmg_path: /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg, dmg: .dmg/, dmg_source_path: OpenSCAD.app
Copier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg
Copier: Copied /private/tmp/dmg.osSNYh/OpenSCAD.app to /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot/Applications/OpenSCAD.app
{'Output': {}}
PkgInfoCreator
{'Input': {'infofile': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/PackageInfo',
           'pkgroot': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/pkgroot',
           'pkgtype': 'flat',
           'template_path': 'PackageInfoTemplate',
           'version': '2019.05'}}
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'org.openscad.OpenSCAD.pkg',
                           'options': 'purge_ds_store',
                           'pkgname': 'OpenSCAD-2019.05',
                           'resources': 'Resources'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'org.openscad.OpenSCAD.pkg',
                                                    'pkg_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/OpenSCAD-2019.05.pkg',
                                                    'version': '2019.05'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '/Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/OpenSCAD-2019.05.pkg'}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/receipts/OpenSCAD-receipt-20210503-085454.plist

The following new items were downloaded:
    Download Path                                                                                   
    -------------                                                                                   
    /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/downloads/OpenSCAD-2019.05.dmg  

The following packages were built:
    Identifier                 Version  Pkg Path                                                                              
    ----------                 -------  --------                                                                              
    org.openscad.OpenSCAD.pkg  2019.05  /Users/admin/Library/AutoPkg/Cache/com.github.jps3.pkg.OpenSCAD/OpenSCAD-2019.05.pkg
```