### PR TITLE
add postinstall as per vendor docs

### DIFF
--- a/Camtasia/Camtasia.munki.recipe
+++ b/Camtasia/Camtasia.munki.recipe
@@ -26,6 +26,9 @@
             <string>%DISPLAY_NAME%</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>postinstall_script</key>
+            <string>#!/bin/bash
+        /Applications/Camtasia\ 2021.app/Contents/Resources/aceinstaller install</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
As of the 2020 releases, the Rogue Amoeba's Audio Capture Engine component they license is recommended to be installed for end users, https://support.techsmith.com/hc/en-us/articles/203727638-Camtasia-Mac-Enterprise-Install-Guidelines
May as well handle that on postinstall