### PR TITLE
Update Arduino Recipes

### DIFF
--- a/Arduino/Arduino.download.recipe
+++ b/Arduino/Arduino.download.recipe
@@ -2,74 +2,59 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest stable Arduino.</string>
-	<key>Identifier</key>
-	<string>com.github.jps3.download.Arduino</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Arduino</string>
-        <key>DOWNLOAD_PAGE</key>
-        <string>https://www.arduino.cc/en/software</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.4</string>
-	<key>Process</key>
-	<array>
+    <key>Description</key>
+    <string>Downloads the latest stable Arduino.
+
+To download the Intel version use "64bit" in the ARCH_TYPE variable.
+To download the Apple Silicon version use "arm64" in the ARCH_TYPE variable.</string>
+    <key>Identifier</key>
+    <string>com.github.jps3.download.Arduino</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Arduino</string>
+        <key>ARCH_TYPE</key>
+        <string>64bit</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>github_repo</key>
+                <string>arduino/arduino-ide</string>
+                <key>asset_regex</key>
+                <string>arduino-ide_([0-9]+(\.[0-9]+)+)_macOS_64bit\.dmg$</string>
+            </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+       <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_PAGE%</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;(https:)?\/\/(?:[^\/]*)arduino\.cc\/(?P&lt;filename&gt;/?[^"']+-macosx\.zip))</string>
-            </dict>
+            <string>EndOfCheckPhase</string>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://downloads.arduino.cc/%filename%</string>
-            </dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-			<key>Arguments</key>
-			<dict>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app/Contents/Info.plist</string>
-			</dict>
-		</dict>
         <dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app</string>
+                <string>%pathname%/Arduino IDE.app</string>
                 <key>requirement</key>
-                <string>identifier "cc.arduino.Arduino" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7KT7ZWMCJT"</string>
+                <string>identifier "cc.arduino.IDE2" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7KT7ZWMCJT"</string>
             </dict>
         </dict>
-	</array>
+    </array>
 </dict>
 </plist>

--- a/Arduino/Arduino.munki.recipe
+++ b/Arduino/Arduino.munki.recipe
@@ -2,69 +2,66 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest Arduino and imports into Munki.</string>
-	<key>Identifier</key>
-	<string>com.github.jps3.munki.Arduino</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Arduino</string>
+    <key>Description</key>
+    <string>Downloads the latest Arduino and imports into Munki.
+
+For the SUPPORTED_ARCH variable use x86_64 for Intel or arm64 for Apple Silicon.</string>
+    <key>Identifier</key>
+    <string>com.github.jps3.munki.Arduino</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Arduino</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-            <string>The open-source Arduino Software (IDE) makes it easy to write code and upload it to the board. It runs on Windows, Mac OS X, and Linux. The environment is written in Java and based on Processing and other open-source software. 
-                
-This software can be used with any Arduino board. 
+        <key>SUPPORTED_ARCH</key>
+        <string>x86_64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>The open-source Arduino Software (IDE) makes it easy to write code and upload it to the board. It runs on Windows, Mac OS X, and Linux. The environment is written in Java and based on Processing and other open-source software.
+
+This software can be used with any Arduino board.
 
 Refer to the Getting Started page for Installation instructions:
 
 https://www.arduino.cc/en/Guide/HomePage
             </string>
-			<key>display_name</key>
-			<string>%NAME%</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>blocking_applications</key>
-			<array>
-				<string>%NAME%</string>
-			</array>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.2</string>
+            <key>display_name</key>
+            <string>Arduino IDE</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>blocking_applications</key>
+            <array>
+                <string>Arduino IDE</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.jps3.download.Arduino</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%dmg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/Arduino/Arduino.pkg.recipe
+++ b/Arduino/Arduino.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Arduino.app</string>
+				<string>%pathname%/Arduino IDE.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Arduino.app</string>
+				<string>%pkgroot%/Applications/Arduino IDE.app</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Hi, @jps3 

The current Arduino download recipes downloads the legacy version.

This PR updates to get the latest from GitHub and adds in support for downloading both Intel and Apple Silicon versions. 

The Munki and Pkg recipes have also been updated to account for the changes in the download recipe. 

Output from a success full Munki run 
```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/jps3-recipes/Arduino/Arduino.munki.recipe 
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/jps3-recipes/Arduino/Arduino.munki.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/jps3-recipes/Arduino/Arduino.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'arduino-ide_([0-9]+(\.[0-9]+)+)_macOS_64bit\.dmg$' among asset(s): arduino-ide_2.2.1_Linux_64bit.AppImage, arduino-ide_2.2.1_Linux_64bit.zip, arduino-ide_2.2.1_macOS_64bit.dmg, arduino-ide_2.2.1_macOS_64bit.zip, arduino-ide_2.2.1_macOS_arm64.dmg, arduino-ide_2.2.1_macOS_arm64.zip, arduino-ide_2.2.1_Windows_64bit.exe, arduino-ide_2.2.1_Windows_64bit.msi, arduino-ide_2.2.1_Windows_64bit.zip, stable-linux.yml, stable-mac.yml, stable.yml
GitHubReleasesInfoProvider: Selected asset 'arduino-ide_2.2.1_macOS_64bit.dmg' from release '2.2.1'
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 31 Aug 2023 14:49:39 GMT
URLDownloader: Storing new ETag header: "0x8DBAA3180D73C74"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.munki.Arduino/downloads/Arduino-2.2.1.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.munki.Arduino/downloads/Arduino-2.2.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.A48UV6/Arduino IDE.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.A48UV6/Arduino IDE.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.A48UV6/Arduino IDE.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Arduino/Arduino-2.2.1__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Arduino/Arduino-2.2.1__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.munki.Arduino/receipts/Arduino.munki-receipt-20230908-173346.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.munki.Arduino/downloads/Arduino-2.2.1.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                         Pkg Repo Path                      Icon Repo Path  
    ----     -------  --------  ------------                         -------------                      --------------  
    Arduino  2.2.1    testing   apps/Arduino/Arduino-2.2.1__1.plist  apps/Arduino/Arduino-2.2.1__1.dmg 
```

Output from a successful pkg run 
```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/jps3-recipes/Arduino/Arduino.pkg.recipe 
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/jps3-recipes/Arduino/Arduino.pkg.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/jps3-recipes/Arduino/Arduino.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'arduino-ide_([0-9]+(\.[0-9]+)+)_macOS_64bit\.dmg$' among asset(s): arduino-ide_2.2.1_Linux_64bit.AppImage, arduino-ide_2.2.1_Linux_64bit.zip, arduino-ide_2.2.1_macOS_64bit.dmg, arduino-ide_2.2.1_macOS_64bit.zip, arduino-ide_2.2.1_macOS_arm64.dmg, arduino-ide_2.2.1_macOS_arm64.zip, arduino-ide_2.2.1_Windows_64bit.exe, arduino-ide_2.2.1_Windows_64bit.msi, arduino-ide_2.2.1_Windows_64bit.zip, stable-linux.yml, stable-mac.yml, stable.yml
GitHubReleasesInfoProvider: Selected asset 'arduino-ide_2.2.1_macOS_64bit.dmg' from release '2.2.1'
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/downloads/Arduino-2.2.1.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/downloads/Arduino-2.2.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.YHPzW1/Arduino IDE.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YHPzW1/Arduino IDE.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YHPzW1/Arduino IDE.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/pkgroot
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/pkgroot/Applications
Copier
Copier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/downloads/Arduino-2.2.1.dmg
Copier: Copied /private/tmp/dmg.qn0YsH/Arduino IDE.app to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/pkgroot/Applications/Arduino IDE.app
PkgInfoCreator
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/receipts/Arduino.pkg-receipt-20230908-170745.plist

The following packages were built:
    Identifier              Version  Pkg Path                                                                                
    ----------              -------  --------                                                                                
    cc.arduino.Arduino.pkg  2.2.1    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.jps3.pkg.Arduino/Arduino-2.2.1.pkg 
```