### PR TITLE
Arduino Patches

### DIFF
--- a/Arduino/Arduino.download.recipe
+++ b/Arduino/Arduino.download.recipe
@@ -26,7 +26,7 @@ To download the Apple Silicon version use "arm64" in the ARCH_TYPE variable.</st
                 <key>github_repo</key>
                 <string>arduino/arduino-ide</string>
                 <key>asset_regex</key>
-                <string>arduino-ide_([0-9]+(\.[0-9]+)+)_macOS_64bit\.dmg$</string>
+                <string>arduino-ide_([0-9]+(\.[0-9]+)+)_macOS_%ARCH_TYPE%\.dmg$</string>
             </dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>

--- a/Arduino/Arduino.pkg.recipe
+++ b/Arduino/Arduino.pkg.recipe
@@ -1,89 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the latest stable Arduino and creates flat *.pkg installer.</string>
-	<key>Identifier</key>
-	<string>com.github.jps3.pkg.Arduino</string>
-	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>Arduino</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.4</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jps3.download.Arduino</string>
-	<key>Process</key>
-	<array>
+		<key>Description</key>
+		<string>Downloads the latest stable Arduino and creates flat *.pkg installer.</string>
+		<key>Identifier</key>
+		<string>com.github.jps3.pkg.Arduino</string>
+		<key>Input</key>
 		<dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-			<key>Arguments</key>
+			<key>NAME</key>
+			<string>Arduino</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>1.0.4</string>
+		<key>ParentRecipe</key>
+		<string>com.github.jps3.download.Arduino</string>
+		<key>Process</key>
+		<array>
 			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-				<key>pkgdirs</key>
+				<key>Processor</key>
+				<string>AppPkgCreator</string>
+				<key>Arguments</key>
 				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Copier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>source_path</key>
-				<string>%pathname%/Arduino IDE.app</string>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Arduino IDE.app</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgInfoCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>template_path</key>
-				<string>PackageInfoTemplate</string>
-				<key>infofile</key>
-				<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-				<key>pkgtype</key>
-				<string>flat</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>id</key>
+					<key>bundleid</key>
 					<string>cc.arduino.Arduino.pkg</string>
-					<key>resources</key>
-					<string>Resources</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-							<key>group</key>
-							<string>admin</string>
-						</dict>
-					</array>
 				</dict>
 			</dict>
-		</dict>
-	</array>
-</dict>
+		</array>
+	</dict>
 </plist>


### PR DESCRIPTION
The last update to the Arduino download recipe doesn't actually use the %ARCH_TYPE% input variable, so it cannot be overridden to allow one to download the ARM flavor.

I also simplified the Arduino .pkg recipe.