### PR TITLE
Updated Camtasia code signature

### DIFF
--- a/Camtasia/Camtasia.download.recipe
+++ b/Camtasia/Camtasia.download.recipe
@@ -34,7 +34,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Camtasia*.app</string>
 				<key>requirement</key>
-				<string>identifier "com.techsmith.camtasia2023" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
+				<string>identifier "Camtasia 2024" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 				<key>strict_verification</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
The Camtasia code signature was updated from:
identifier "com.techsmith.camtasia2023" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"

to:
identifier "Camtasia 2024" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"