### PR TITLE
Update Camtasia.munki.recipe

### DIFF
--- a/Camtasia/Camtasia.munki.recipe
+++ b/Camtasia/Camtasia.munki.recipe
@@ -31,7 +31,7 @@
 /Applications/Camtasia\ 2023.app/Contents/Resources/aceinstaller install --silent
             </string>
             <!--
-                $ "/Applications/Camtasia 2023.app/Contents//Resources/aceinstaller" -h
+                $ "/Applications/Camtasia.app/Contents//Resources/aceinstaller" -h
                 aceinstaller: <action>
 
                     help


### PR DESCRIPTION
Removed the specific 2023 version from the postinstall script. The latest Camtasia installer does not specify versions anymore in the file name.